### PR TITLE
Pre-sort arbitrage pair combinations

### DIFF
--- a/cryptopy/src/trading/ArbitrageSimulator.py
+++ b/cryptopy/src/trading/ArbitrageSimulator.py
@@ -26,7 +26,7 @@ class ArbitrageSimulator:
         self.price_df = price_df
         self.volume_df = volume_df
         self.portfolio_manager = portfolio_manager
-        self.pair_combinations = pair_combinations
+        self.pair_combinations = sorted(pair_combinations, key=lambda x: x[0])
         self.ml_model = ml_model
         self.trades_before_prediction = trades_before_prediction
         self.trade_results = []
@@ -105,7 +105,7 @@ class ArbitrageSimulator:
             market_prices, price_field, trend_parameters
         )
 
-        for pair in sorted(self.pair_combinations, key=lambda x: x[0]):
+        for pair in self.pair_combinations:
             if "XRP/USD" in pair:
                 continue
 


### PR DESCRIPTION
## Summary
- sort pair combinations once during simulator initialization
- iterate directly over the cached ordering when finding daily opportunities

## Testing
- python cryptopy/scripts/simulations/simulation.py *(fails: ModuleNotFoundError: No module named 'river')*

------
https://chatgpt.com/codex/tasks/task_e_68d6cade06b08324b044218e00d1e537