### PR TITLE
Skip caching cointegration analytics until the lookback window is complete

### DIFF
--- a/cryptopy/src/trading/ArbitrageSimulator.py
+++ b/cryptopy/src/trading/ArbitrageSimulator.py
@@ -264,6 +264,12 @@ class ArbitrageSimulator:
     def get_cointegration_and_spread_info(self, pair, price_df_filtered, current_date):
         currency_fees = {pair[0]: {"taker": 0.002}, pair[1]: {"taker": 0.002}}
 
+        days_back = self.parameters.get("days_back", 0)
+        if not PairAnalyticsCache._has_complete_window(
+            price_df_filtered, current_date, days_back
+        ):
+            return None
+
         cached_analytics = None
         if self._pair_analytics_cache is not None:
             cached_analytics = self._pair_analytics_cache.ensure(


### PR DESCRIPTION
## Summary
- ensure cached cointegration analytics are skipped when the filtered price window is incomplete
- add a reusable helper to detect incomplete lookback windows and use it in the simulator before requesting analytics

## Testing
- `pytest` *(fails: missing ../../config/exchange_config.yaml and dash_bootstrap_components dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d8089bd2c48324ba92bd3cc7833ca7