### PR TITLE
Add cached spread series support and tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,109 @@
+import sys
+import types
+
+
+def _ensure_dummy_dash_modules():
+    if "dash" not in sys.modules:
+        dash_module = types.ModuleType("dash")
+        dash_module.html = types.SimpleNamespace(
+            Div=lambda *args, **kwargs: None,
+            Label=lambda *args, **kwargs: None,
+            H1=lambda *args, **kwargs: None,
+            H2=lambda *args, **kwargs: None,
+            Span=lambda *args, **kwargs: None,
+        )
+        dash_module.dcc = types.SimpleNamespace(
+            Dropdown=lambda *args, **kwargs: None,
+            Interval=lambda *args, **kwargs: None,
+            Graph=lambda *args, **kwargs: None,
+        )
+        dash_module.__spec__ = types.SimpleNamespace()
+        sys.modules["dash"] = dash_module
+
+    if "dash_bootstrap_components" not in sys.modules:
+        dbc_module = types.ModuleType("dash_bootstrap_components")
+        dbc_module.__getattr__ = lambda name: (lambda *args, **kwargs: None)
+        dbc_module.__spec__ = types.SimpleNamespace()
+        sys.modules["dash_bootstrap_components"] = dbc_module
+
+    if "river" not in sys.modules:
+        river_module = types.ModuleType("river")
+        river_module.__spec__ = types.SimpleNamespace()
+        river_module.__path__ = []
+        for submodule in [
+            "compose",
+            "preprocessing",
+            "linear_model",
+            "feature_extraction",
+            "naive_bayes",
+            "tree",
+            "forest",
+            "ensemble",
+        ]:
+            module_name = f"river.{submodule}"
+            sub_module = types.ModuleType(module_name)
+            sub_module.__spec__ = types.SimpleNamespace()
+            sys.modules[module_name] = sub_module
+            setattr(river_module, submodule, sub_module)
+        sys.modules["river"] = river_module
+
+    if "newsapi" not in sys.modules:
+        newsapi_module = types.ModuleType("newsapi")
+
+        class _DummyNewsApiClient:
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+            def get_sources(self, *args, **kwargs):
+                return {}
+
+            def get_everything(self, *args, **kwargs):
+                return {}
+
+        newsapi_module.NewsApiClient = _DummyNewsApiClient
+        newsapi_module.__spec__ = types.SimpleNamespace()
+        sys.modules["newsapi"] = newsapi_module
+
+        newsapi_exception_module = types.ModuleType("newsapi.newsapi_exception")
+
+        class _DummyNewsAPIException(Exception):
+            pass
+
+        newsapi_exception_module.NewsAPIException = _DummyNewsAPIException
+        newsapi_exception_module.__spec__ = types.SimpleNamespace()
+        sys.modules["newsapi.newsapi_exception"] = newsapi_exception_module
+
+    if "plotly" not in sys.modules:
+        plotly_module = types.ModuleType("plotly")
+        plotly_module.__spec__ = types.SimpleNamespace()
+        plotly_module.__path__ = []
+
+        class _DummyFigure:
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+
+        graph_objs_module = types.ModuleType("plotly.graph_objs")
+        graph_objs_module.Figure = _DummyFigure
+        graph_objs_module.__spec__ = types.SimpleNamespace()
+
+        graph_objects_module = types.ModuleType("plotly.graph_objects")
+        graph_objects_module.Figure = _DummyFigure
+        graph_objects_module.__spec__ = types.SimpleNamespace()
+
+        plotly_module.graph_objs = graph_objs_module
+        plotly_module.graph_objects = graph_objects_module
+
+        subplots_module = types.ModuleType("plotly.subplots")
+        subplots_module.make_subplots = lambda *args, **kwargs: None
+        subplots_module.__spec__ = types.SimpleNamespace()
+
+        sys.modules["plotly"] = plotly_module
+        sys.modules["plotly.graph_objs"] = graph_objs_module
+        sys.modules["plotly.graph_objects"] = graph_objects_module
+        sys.modules["plotly.subplots"] = subplots_module
+        sys.modules["plotly.express"] = types.ModuleType("plotly.express")
+
+
+_ensure_dummy_dash_modules()

--- a/cryptopy/tests/trading/test_cache_utils.py
+++ b/cryptopy/tests/trading/test_cache_utils.py
@@ -1,0 +1,67 @@
+import pandas as pd
+import pytest
+
+from cryptopy.src.trading.cache_utils import PairAnalyticsCache
+from cryptopy.src.trading.ArbitrageSimulator import ArbitrageSimulator
+
+
+class DummyPortfolioManager:
+    pass
+
+
+def _store_spread(cache: PairAnalyticsCache, pair, date, value):
+    spread_series = pd.Series([value], index=[pd.Timestamp(date)])
+    cache.store(
+        pair,
+        pd.Timestamp(date),
+        p_value=0.05,
+        hedge_ratio=1.0,
+        spread=spread_series,
+    )
+
+
+def test_get_spread_series_returns_recent_values(tmp_path):
+    cache = PairAnalyticsCache(tmp_path)
+    pair = ("BTC/USD", "ETH/USD")
+
+    _store_spread(cache, pair, "2024-01-01", 1.0)
+    _store_spread(cache, pair, "2024-01-02", 2.0)
+    _store_spread(cache, pair, "2024-01-03", 3.0)
+
+    series = cache.get_spread_series(pair, rolling_window=2)
+
+    assert list(series.index) == [pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-03")]
+    assert list(series.values) == [2.0, 3.0]
+
+
+def test_get_cached_spread_metrics_uses_cached_series(tmp_path):
+    cache = PairAnalyticsCache(tmp_path)
+    pair = ("BTC/USD", "ETH/USD")
+
+    _store_spread(cache, pair, "2024-01-01", 1.0)
+    _store_spread(cache, pair, "2024-01-02", 2.0)
+
+    parameters = {
+        "rolling_window": 2,
+        "spread_threshold": 1.0,
+        "spread_limit": 2.0,
+        "expected_holding_days": 0,
+    }
+
+    simulator = ArbitrageSimulator(
+        parameters=parameters,
+        price_df=pd.DataFrame(),
+        volume_df=pd.DataFrame(),
+        portfolio_manager=DummyPortfolioManager(),
+        pair_combinations=[pair],
+        pair_analytics_cache=cache,
+    )
+
+    current_date = pd.Timestamp("2024-01-02")
+    cached_spread = cache.load(pair, current_date)["spread"]
+
+    metrics = simulator._get_cached_spread_metrics(pair, current_date, cached_spread)
+
+    spread_mean = metrics["spread_mean"].dropna()
+    assert not spread_mean.empty
+    assert spread_mean.iloc[-1] == pytest.approx(1.5)


### PR DESCRIPTION
## Summary
- extend `PairAnalyticsCache` with a helper that reconstructs recent spread series from cached summaries
- update `ArbitrageSimulator` to reuse the cached spread series when only scalar spreads are available before computing metrics
- add lightweight stubs and targeted pytest coverage to exercise the cached metrics flow

## Testing
- pytest cryptopy/tests/trading/test_cache_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d8e092d8448324801f05aeebb8cfad