### PR TITLE
Handle duplicate cache summary rows

### DIFF
--- a/cryptopy/src/trading/cache_utils.py
+++ b/cryptopy/src/trading/cache_utils.py
@@ -168,6 +168,9 @@ class PairAnalyticsCache:
         except KeyError:
             return None
 
+        if isinstance(summary_row, pd.DataFrame):
+            summary_row = summary_row.iloc[-1]
+
         crit_values = summary_row[
             ["crit_value_1", "crit_value_2", "crit_value_3"]
         ].tolist()


### PR DESCRIPTION
## Summary
- ensure cached summary lookups handle duplicate entries by reducing them to the latest row

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d97cf584e483249588b85fe4b3dc27