### PR TITLE
Log reduced-fee triangular arbitrage opportunities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+reduced_fee_opportunities.jsonl

--- a/cryptopy/scripts/trading/run_triangular_arbitrage.py
+++ b/cryptopy/scripts/trading/run_triangular_arbitrage.py
@@ -37,6 +37,10 @@ from cryptopy.src.trading.triangular_arbitrage import (
     TriangularRoute,
     simulate_opportunity_with_order_books,
 )
+from cryptopy.src.trading.triangular_arbitrage.reduced_fee_logger import (
+    ReducedFeeLogContext,
+    ReducedFeeOpportunityLogger,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -894,6 +898,7 @@ async def evaluate_and_execute(
     slippage_usage_fraction: float,
     trigger_queue: "asyncio.Queue[str]",
     stop_event: asyncio.Event,
+    reduced_fee_logger: Optional[ReducedFeeOpportunityLogger] = None,
 ) -> None:
     """Evaluate cached prices and execute profitable opportunities."""
 
@@ -989,6 +994,13 @@ async def evaluate_and_execute(
                 logger.info("; ".join(message_parts))
             continue
 
+        evaluation_context = ReducedFeeLogContext(
+            reason=reason_summary,
+            evaluation_started=evaluation_started_wall_clock,
+            candidate_routes=candidate_count,
+            evaluable_routes=evaluable_route_count,
+        )
+
         try:
             opportunities, stats = calculator.find_profitable_routes(
                 candidate_routes,
@@ -1021,6 +1033,13 @@ async def evaluate_and_execute(
                 f"{stats.evaluation_errors} route(s) encountered errors, "
                 f"{stats.filtered_by_length} route(s) exceeded the length limit."
             )
+            if reduced_fee_logger and stats.best_opportunity:
+                reduced_fee_logger.log_from_stats(
+                    fresh_prices,
+                    stats.best_opportunity,
+                    min_profit_percentage=min_profit_percentage,
+                    context=evaluation_context,
+                )
             if stats.evaluation_error_reasons:
                 sorted_reasons = sorted(
                     stats.evaluation_error_reasons.items(), key=lambda item: item[1], reverse=True
@@ -1044,8 +1063,11 @@ async def evaluate_and_execute(
 
         selected_opportunity: Optional[TriangularOpportunity] = None
         selected_raw: Optional[TriangularOpportunity] = None
+        selected_slippage_details: Optional[Dict[str, float]] = None
+        selected_slippage_impact_pct: float = 0.0
 
         for index, raw_best in enumerate(opportunities):
+            candidate_slippage_details: Optional[Dict[str, float]] = None
             if index == 0:
                 logger.info(
                     f"Best opportunity: route={' -> '.join(raw_best.route.symbols)} "
@@ -1175,6 +1197,13 @@ async def evaluate_and_execute(
                     pre_trade_simulation.opportunity.profit,
                     pre_trade_simulation.opportunity.profit_percentage,
                 )
+                candidate_slippage_details = {
+                    "source": "pre_trade",
+                    "total_pct": total_slippage,
+                    "max_leg_price_pct": max_leg_slippage,
+                    "max_leg_output_pct": max_output_slippage,
+                    "adjusted_profit_pct": pre_trade_simulation.opportunity.profit_percentage,
+                }
                 best = pre_trade_simulation.opportunity
 
             if slippage_action != "ignore":
@@ -1497,9 +1526,24 @@ async def evaluate_and_execute(
                             for leg in slippage_decision.simulation.legs
                         )
                         logger.info("Per-leg slippage estimates: %s", leg_details)
+                    details = candidate_slippage_details or {}
+                    if "total_pct" in details and "pre_trade_total_pct" not in details:
+                        details["pre_trade_total_pct"] = details["total_pct"]
+                    details.update(
+                        {
+                            "source": "slippage_action",
+                            "total_pct": slippage_decision.total_slippage_pct,
+                            "max_leg_price_pct": slippage_decision.max_leg_slippage_pct,
+                            "max_leg_output_pct": slippage_decision.max_leg_output_slippage_pct,
+                            "scale": slippage_decision.scale,
+                        }
+                    )
+                    candidate_slippage_details = details
 
             selected_opportunity = best
             selected_raw = raw_best
+            selected_slippage_details = candidate_slippage_details
+            selected_slippage_impact_pct = raw_best.profit_percentage - best.profit_percentage
             break
 
         if selected_opportunity is None or selected_raw is None:
@@ -1511,6 +1555,8 @@ async def evaluate_and_execute(
 
         best = selected_opportunity
         raw_best = selected_raw
+        slippage_impact_pct = selected_slippage_impact_pct
+        slippage_details_for_logging = selected_slippage_details
 
         planning_ready_at = perf_counter()
         planning_latency = planning_ready_at - evaluation_started_at
@@ -1527,6 +1573,16 @@ async def evaluate_and_execute(
                 best.profit_percentage,
                 min_profit_percentage,
             )
+            if reduced_fee_logger and raw_best is not None:
+                reduced_fee_logger.log_from_opportunity(
+                    fresh_prices,
+                    raw_best,
+                    best,
+                    min_profit_percentage=min_profit_percentage,
+                    context=evaluation_context,
+                    slippage_impact_pct=slippage_impact_pct,
+                    slippage_details=slippage_details_for_logging,
+                )
             continue
 
         profit_signature = (round(best.final_amount, 8), round(best.profit_percentage, 4))
@@ -1741,6 +1797,7 @@ async def run_from_args(args: argparse.Namespace) -> None:
         exchange,
         slippage_buffer=args.slippage_buffer,
     )
+    reduced_fee_logger = ReducedFeeOpportunityLogger(exchange)
     executor: Optional[TriangularArbitrageExecutor] = None
     staggered_slippage = (
         args.staggered_slippage_assumption
@@ -1869,6 +1926,7 @@ async def run_from_args(args: argparse.Namespace) -> None:
             slippage_usage_fraction=args.slippage_usage_fraction,
             trigger_queue=trigger_queue,
             stop_event=stop_event,
+            reduced_fee_logger=reduced_fee_logger,
         ),
         name="arbitrage-evaluator",
     )

--- a/cryptopy/src/trading/triangular_arbitrage/reduced_fee_logger.py
+++ b/cryptopy/src/trading/triangular_arbitrage/reduced_fee_logger.py
@@ -1,0 +1,178 @@
+"""Helpers for logging hypothetical opportunities under reduced taker fees."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from .calculator import TriangularArbitrageCalculator
+from .models import PriceSnapshot, TriangularOpportunity, TriangularRoute
+
+
+class _ReducedFeeExchangeProxy:
+    """Delegate exchange wrapper that caps taker fees to a reduced rate."""
+
+    def __init__(self, exchange: Any, reduced_taker_fee: float) -> None:
+        self._exchange = exchange
+        self._reduced_taker_fee = float(reduced_taker_fee)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._exchange, name)
+
+    def get_taker_fee(self, symbol: str) -> float:  # pragma: no cover - thin wrapper
+        try:
+            current = float(self._exchange.get_taker_fee(symbol))
+        except Exception:  # pragma: no cover - defensive guard
+            current = self._reduced_taker_fee
+        return min(current, self._reduced_taker_fee)
+
+
+@dataclass
+class ReducedFeeLogContext:
+    reason: str
+    evaluation_started: str
+    candidate_routes: int
+    evaluable_routes: int
+
+
+class ReducedFeeOpportunityLogger:
+    """Re-evaluates opportunities with reduced fees and logs profitable cases."""
+
+    def __init__(
+        self,
+        exchange: Any,
+        *,
+        reduced_taker_fee: float = 0.0024,
+        log_path: Path | str = "reduced_fee_opportunities.jsonl",
+    ) -> None:
+        self._log_path = Path(log_path)
+        self._reduced_taker_fee = float(reduced_taker_fee)
+        self._calculator = TriangularArbitrageCalculator(
+            _ReducedFeeExchangeProxy(exchange, self._reduced_taker_fee)
+        )
+
+    # ------------------------------------------------------------------ #
+    def log_from_opportunity(
+        self,
+        prices: Mapping[str, PriceSnapshot],
+        raw_opportunity: TriangularOpportunity,
+        adjusted_opportunity: TriangularOpportunity,
+        *,
+        min_profit_percentage: float,
+        context: ReducedFeeLogContext,
+        slippage_impact_pct: float,
+        slippage_details: Optional[Dict[str, float]] = None,
+    ) -> None:
+        """Log the opportunity if reduced fees would render it profitable."""
+
+        reduced = self._evaluate_route(prices, raw_opportunity.route, raw_opportunity.starting_amount)
+        if reduced is None:
+            return
+
+        estimated_profit_pct = reduced.profit_percentage - slippage_impact_pct
+        if estimated_profit_pct <= min_profit_percentage:
+            return
+        estimated_profit = reduced.starting_amount * (estimated_profit_pct / 100.0)
+
+        record = {
+            "observed_at": datetime.now(timezone.utc).isoformat(),
+            "context": {
+                "reason": context.reason,
+                "evaluation_started": context.evaluation_started,
+                "candidate_routes": context.candidate_routes,
+                "evaluable_routes": context.evaluable_routes,
+            },
+            "route": list(raw_opportunity.route.symbols),
+            "starting_currency": raw_opportunity.route.starting_currency,
+            "starting_amount": reduced.starting_amount,
+            "current": {
+                "profit": adjusted_opportunity.profit,
+                "profit_pct": adjusted_opportunity.profit_percentage,
+            },
+            "reduced_fee": {
+                "capped_taker_fee": self._reduced_taker_fee,
+                "profit_no_slippage": reduced.profit,
+                "profit_pct_no_slippage": reduced.profit_percentage,
+                "estimated_profit": estimated_profit,
+                "estimated_profit_pct": estimated_profit_pct,
+                "profit_gain_pct": estimated_profit_pct - adjusted_opportunity.profit_percentage,
+            },
+            "slippage": slippage_details or {
+                "estimated_impact_pct": max(slippage_impact_pct, 0.0),
+            },
+        }
+
+        self._append(record)
+
+    def log_from_stats(
+        self,
+        prices: Mapping[str, PriceSnapshot],
+        opportunity: TriangularOpportunity,
+        *,
+        min_profit_percentage: float,
+        context: ReducedFeeLogContext,
+    ) -> None:
+        """Evaluate a non-profitable opportunity (no slippage adjustments)."""
+
+        reduced = self._evaluate_route(prices, opportunity.route, opportunity.starting_amount)
+        if reduced is None:
+            return
+
+        if reduced.profit_percentage <= min_profit_percentage:
+            return
+
+        record = {
+            "observed_at": datetime.now(timezone.utc).isoformat(),
+            "context": {
+                "reason": context.reason,
+                "evaluation_started": context.evaluation_started,
+                "candidate_routes": context.candidate_routes,
+                "evaluable_routes": context.evaluable_routes,
+            },
+            "route": list(opportunity.route.symbols),
+            "starting_currency": opportunity.route.starting_currency,
+            "starting_amount": reduced.starting_amount,
+            "current": {
+                "profit": opportunity.profit,
+                "profit_pct": opportunity.profit_percentage,
+            },
+            "reduced_fee": {
+                "capped_taker_fee": self._reduced_taker_fee,
+                "profit_no_slippage": reduced.profit,
+                "profit_pct_no_slippage": reduced.profit_percentage,
+                "estimated_profit": reduced.profit,
+                "estimated_profit_pct": reduced.profit_percentage,
+                "profit_gain_pct": reduced.profit_percentage - opportunity.profit_percentage,
+            },
+            "slippage": {"estimated_impact_pct": 0.0},
+        }
+
+        self._append(record)
+
+    # ------------------------------------------------------------------ #
+    def _evaluate_route(
+        self,
+        prices: Mapping[str, PriceSnapshot],
+        route: TriangularRoute,
+        starting_amount: float,
+    ) -> Optional[TriangularOpportunity]:
+        try:
+            return self._calculator.evaluate_route(
+                route,
+                dict(prices),
+                starting_amount=starting_amount,
+                min_profit_percentage=float("-inf"),
+            )
+        except Exception:  # pragma: no cover - defensive guard against transient data issues
+            return None
+
+    def _append(self, record: Dict[str, Any]) -> None:
+        try:
+            if not self._log_path.parent.exists():
+                self._log_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._log_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record) + "\n")
+        except OSError:  # pragma: no cover - best effort logging
+            pass


### PR DESCRIPTION
## Summary
- Restore the simple arbitrage helper to its original implementation so the class remains unchanged for other workflows.
- Add a reduced-fee triangular arbitrage logger that re-evaluates routes with a 0.24% taker fee cap and appends qualifying opportunities to a JSONL file.
- Integrate the reduced-fee logger into the realtime triangular arbitrage evaluator so skipped opportunities with positive hypothetical returns (after slippage adjustments) are persisted for later review.

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69053a3890a88324a70b04f80467ead1